### PR TITLE
Strip redundant -lmpi from pnetcdf-config --libs

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,3 +37,14 @@ if [ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]; then
 fi
 
 make install
+
+# Upstream 1.15.0's configure leaks a redundant `-lmpi` into `pnetcdf-config --libs`
+# ("extra libraries"), whereas 1.14.1 (incl. when rebuilt against mpich 5) left it
+# empty. The shared lib already links libmpi and pnetcdf.pc omits it, but the stray
+# `-lmpi` breaks downstreams (e.g. ParallelIO) that treat `--libs` as the full link
+# line. Restore the pre-1.15.0 empty value. Anchored to `^LIBS=` so FLIBS/FCLIBS
+# (Fortran link flags) are untouched; temp-file rewrite is portable across seds.
+_pc="${PREFIX}/bin/pnetcdf-config"
+sed 's/^LIBS=.*/LIBS=""/' "${_pc}" > "${_pc}.tmp"
+cat "${_pc}.tmp" > "${_pc}"   # preserve exec permissions
+rm -f "${_pc}.tmp"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: "1.15.0"
-  build_number: 0
+  build_number: 1
 
 package:
   name: libpnetcdf
@@ -57,6 +57,10 @@ tests:
       - test ! -f ${PREFIX}/lib/libpnetcdf.a
       - pnetcdf-config --has-c++      | grep -q yes
       - pnetcdf-config --has-fortran  | grep -q yes
+      # `--libs` reports "extra" link libraries; for our shared-only build it must
+      # be empty (the dylib already links libmpi). Guards against the upstream
+      # 1.15.0 regression that leaked a redundant `-lmpi` and broke ParallelIO.
+      - '! pnetcdf-config --libs | grep -q -- -lmpi'
       # disabled for now
       # - pnetcdf-config --netcdf4      | grep -q enabled
 


### PR DESCRIPTION
PnetCDF 1.15.0's configure records -lmpi in LIBS, so `pnetcdf-config --libs` now reports "-lmpi" where 1.14.1 reported an empty string (confirmed empty even for 1.14.1 rebuilt against mpich 5, and the regression appears identically under both mpich and openmpi, so it is the pnetcdf source rather than the MPI provider).

The -lmpi is redundant for our shared-only build: libpnetcdf already links libmpi directly (it is in the dylib's load commands) and pnetcdf.pc correctly omits it. But the stray flag breaks downstreams such as [ParallelIO](https://github.com/conda-forge/parallelio-feedstock/pull/34), whose CMake treats `pnetcdf-config --libs` as the complete link line and only injects -lpnetcdf when --libs is empty; the non-empty "-lmpi" suppressed that, dropping -lpnetcdf and failing the macOS link with undefined ncmpi_ symbols.

Restore the pre-1.15.0 behavior by resetting LIBS to empty in the installed pnetcdf-config (anchored to ^LIBS= so the Fortran FLIBS/FCLIBS are untouched), add a test guarding against -lmpi reappearing in --libs, and bump the build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
